### PR TITLE
feat: add Stripe checkout redirect pages

### DIFF
--- a/src/app/checkout-cancel/page.tsx
+++ b/src/app/checkout-cancel/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useEffect } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 
-export default function CheckoutCancelPage() {
+function CheckoutCancelContent() {
   const searchParams = useSearchParams();
   const orderId = searchParams.get('order_id');
 
@@ -64,5 +64,22 @@ export default function CheckoutCancelPage() {
         You can close this window and return to the app.
       </p>
     </div>
+  );
+}
+
+export default function CheckoutCancelPage() {
+  return (
+    <Suspense fallback={
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+      }}>
+        Loading...
+      </div>
+    }>
+      <CheckoutCancelContent />
+    </Suspense>
   );
 }

--- a/src/app/checkout-success/page.tsx
+++ b/src/app/checkout-success/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useEffect } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 
-export default function CheckoutSuccessPage() {
+function CheckoutSuccessContent() {
   const searchParams = useSearchParams();
   const orderId = searchParams.get('order_id');
 
@@ -64,5 +64,22 @@ export default function CheckoutSuccessPage() {
         You can close this window and return to the app.
       </p>
     </div>
+  );
+}
+
+export default function CheckoutSuccessPage() {
+  return (
+    <Suspense fallback={
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+      }}>
+        Loading...
+      </div>
+    }>
+      <CheckoutSuccessContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Changes

- Added `/checkout-success` page for successful Stripe payments
- Added `/checkout-cancel` page for cancelled payments
- Both pages display appropriate messaging with order ID
- Auto-close after 3 seconds for better mobile UX
- Resolves 404 errors when mobile users complete checkout

## Features

- Success page shows ✅ with green confirmation
- Cancel page shows ❌ with red message
- Order ID displayed for reference
- Instructions to close window and return to app
- Auto-close functionality for convenience

## Related

- Mobile PR: acebackapp/mobile#117
- API PR: acebackapp/api#138

## Testing

1. Create sticker order from mobile app
2. Complete Stripe checkout with test card: `4242 4242 4242 4242`
3. Verify redirect to success page (no 404)
4. Page should auto-close after 3 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)