### PR TITLE
feat: add automated Cloudflare deployment to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,27 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  deploy:
+    name: Deploy to Cloudflare
+    runs-on: ubuntu-latest
+    needs: [lint, test, build]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Deploy to Cloudflare Workers
+        run: npm run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Problem

Currently, deployments to Cloudflare Workers require manual `npm run deploy` after merging to main. This means production can be out of sync with the main branch.

## Solution

Added automated deployment job to CI workflow that:
- ✅ Runs only on main branch pushes (not PRs)
- ✅ Depends on lint, test, and build jobs passing first
- ✅ Uses `npm run deploy` to deploy to Cloudflare Workers
- ✅ Requires `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets

## Setup Required

Before merging, add these repository secrets:
1. Go to Settings → Secrets and variables → Actions
2. Add `CLOUDFLARE_API_TOKEN` - Get from Cloudflare dashboard
3. Add `CLOUDFLARE_ACCOUNT_ID` - Get from Cloudflare dashboard

## Testing

After merge, the deploy job will run automatically and you can verify:
- Check Actions tab for successful deployment
- Visit https://aceback.app to confirm latest changes are live

🤖 Generated with [Claude Code](https://claude.com/claude-code)