### PR TITLE
feat: add deep linking to checkout success/cancel pages

### DIFF
--- a/src/app/checkout-cancel/page.tsx
+++ b/src/app/checkout-cancel/page.tsx
@@ -8,13 +8,19 @@ function CheckoutCancelContent() {
   const orderId = searchParams.get('order_id');
 
   useEffect(() => {
-    // Auto-close after 3 seconds
+    // Attempt to deep link back to the app
+    const deepLinkUrl = `aceback://checkout/cancel${orderId ? `?order_id=${orderId}` : ''}`;
+
+    // Try to open the app via deep link
+    window.location.href = deepLinkUrl;
+
+    // Fallback: close window after 3 seconds if deep link doesn't work
     const timer = setTimeout(() => {
       window.close();
     }, 3000);
 
     return () => clearTimeout(timer);
-  }, []);
+  }, [orderId]);
 
   return (
     <div style={{

--- a/src/app/checkout-success/page.tsx
+++ b/src/app/checkout-success/page.tsx
@@ -8,13 +8,19 @@ function CheckoutSuccessContent() {
   const orderId = searchParams.get('order_id');
 
   useEffect(() => {
-    // Auto-close after 3 seconds
+    // Attempt to deep link back to the app
+    const deepLinkUrl = `aceback://checkout/success${orderId ? `?order_id=${orderId}` : ''}`;
+
+    // Try to open the app via deep link
+    window.location.href = deepLinkUrl;
+
+    // Fallback: close window after 3 seconds if deep link doesn't work
     const timer = setTimeout(() => {
       window.close();
     }, 3000);
 
     return () => clearTimeout(timer);
-  }, []);
+  }, [orderId]);
 
   return (
     <div style={{


### PR DESCRIPTION
## Summary

After Stripe checkout completes, the pages now attempt to deep link back to the mobile app using the `aceback://` URL scheme. This provides a seamless experience where users are automatically returned to the app after payment.

## Changes

- Success page redirects to `aceback://checkout/success?order_id={id}`
- Cancel page redirects to `aceback://checkout/cancel?order_id={id}`
- Fallback to auto-close window after 3s if deep link fails

## Testing

- Complete a test purchase and verify app opens after success
- Cancel a payment and verify app opens after cancel
- Test on devices without app installed to verify fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)