### PR TITLE
feat: add Stripe Connect return pages for deep linking

### DIFF
--- a/__tests__/connect-refresh/page.test.tsx
+++ b/__tests__/connect-refresh/page.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import ConnectRefreshPage from '@/app/connect-refresh/page';
+
+// We can't easily test window.location.href changes in jsdom
+// Focus on testing the rendered content
+
+describe('ConnectRefreshPage', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders the session expired title', () => {
+    render(<ConnectRefreshPage />);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Session Expired'
+    );
+  });
+
+  it('renders the expired message', () => {
+    render(<ConnectRefreshPage />);
+    expect(
+      screen.getByText('Your payout setup session has expired.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the returning to app message', () => {
+    render(<ConnectRefreshPage />);
+    expect(screen.getByText('Returning to the app...')).toBeInTheDocument();
+  });
+
+  it('renders the retry instruction', () => {
+    render(<ConnectRefreshPage />);
+    expect(
+      screen.getByText(
+        'Please try again from your profile to complete the setup.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders the refresh emoji', () => {
+    render(<ConnectRefreshPage />);
+    expect(screen.getByText('🔄')).toBeInTheDocument();
+  });
+});

--- a/__tests__/connect-return/page.test.tsx
+++ b/__tests__/connect-return/page.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import ConnectReturnPage from '@/app/connect-return/page';
+
+// We can't easily test window.location.href changes in jsdom
+// Focus on testing the rendered content
+
+describe('ConnectReturnPage', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders the success title', () => {
+    render(<ConnectReturnPage />);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Payout Setup Complete!'
+    );
+  });
+
+  it('renders the success message', () => {
+    render(<ConnectReturnPage />);
+    expect(
+      screen.getByText('You can now receive reward payments via credit card.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders the returning to app message', () => {
+    render(<ConnectReturnPage />);
+    expect(screen.getByText('Returning to the app...')).toBeInTheDocument();
+  });
+
+  it('renders the fallback instruction', () => {
+    render(<ConnectReturnPage />);
+    expect(
+      screen.getByText(
+        "If the app doesn't open, you can close this window and return manually."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders the success emoji', () => {
+    render(<ConnectReturnPage />);
+    expect(screen.getByText('✅')).toBeInTheDocument();
+  });
+});

--- a/src/app/connect-refresh/page.tsx
+++ b/src/app/connect-refresh/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function ConnectRefreshPage() {
+  useEffect(() => {
+    // Attempt to deep link back to the app
+    const deepLinkUrl = 'com.aceback.app://connect-refresh';
+
+    // Try to open the app via deep link
+    window.location.href = deepLinkUrl;
+
+    // Fallback: close window after 3 seconds if deep link doesn't work
+    const timer = setTimeout(() => {
+      window.close();
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minHeight: '100vh',
+      padding: '20px',
+      textAlign: 'center',
+      fontFamily: 'system-ui, -apple-system, sans-serif',
+      backgroundColor: '#f5f5f5'
+    }}>
+      <div style={{
+        fontSize: '64px',
+        marginBottom: '24px'
+      }}>
+        🔄
+      </div>
+      <h1 style={{
+        fontSize: '28px',
+        fontWeight: 'bold',
+        marginBottom: '12px',
+        color: '#8E44AD'
+      }}>
+        Session Expired
+      </h1>
+      <p style={{
+        fontSize: '16px',
+        color: '#666',
+        marginBottom: '8px'
+      }}>
+        Your payout setup session has expired.
+      </p>
+      <p style={{
+        fontSize: '14px',
+        color: '#999',
+        marginTop: '24px'
+      }}>
+        Returning to the app...
+      </p>
+      <p style={{
+        fontSize: '12px',
+        color: '#bbb',
+        marginTop: '8px'
+      }}>
+        Please try again from your profile to complete the setup.
+      </p>
+    </div>
+  );
+}

--- a/src/app/connect-return/page.tsx
+++ b/src/app/connect-return/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function ConnectReturnPage() {
+  useEffect(() => {
+    // Attempt to deep link back to the app
+    const deepLinkUrl = 'com.aceback.app://connect-return';
+
+    // Try to open the app via deep link
+    window.location.href = deepLinkUrl;
+
+    // Fallback: close window after 3 seconds if deep link doesn't work
+    const timer = setTimeout(() => {
+      window.close();
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minHeight: '100vh',
+      padding: '20px',
+      textAlign: 'center',
+      fontFamily: 'system-ui, -apple-system, sans-serif',
+      backgroundColor: '#f5f5f5'
+    }}>
+      <div style={{
+        fontSize: '64px',
+        marginBottom: '24px'
+      }}>
+        ✅
+      </div>
+      <h1 style={{
+        fontSize: '28px',
+        fontWeight: 'bold',
+        marginBottom: '12px',
+        color: '#2ECC71'
+      }}>
+        Payout Setup Complete!
+      </h1>
+      <p style={{
+        fontSize: '16px',
+        color: '#666',
+        marginBottom: '8px'
+      }}>
+        You can now receive reward payments via credit card.
+      </p>
+      <p style={{
+        fontSize: '14px',
+        color: '#999',
+        marginTop: '24px'
+      }}>
+        Returning to the app...
+      </p>
+      <p style={{
+        fontSize: '12px',
+        color: '#bbb',
+        marginTop: '8px'
+      }}>
+        If the app doesn&apos;t open, you can close this window and return manually.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `/connect-return` page for successful Stripe Connect onboarding
- Add `/connect-refresh` page for expired Stripe Connect sessions
- Both pages attempt deep link to mobile app, with fallback messaging

These pages are required for the Stripe Connect integration to work properly:
- When a user completes Stripe Connect onboarding, Stripe redirects to `aceback.app/connect-return`
- When a session expires, Stripe redirects to `aceback.app/connect-refresh`

The pages try to open the mobile app via deep link (`com.aceback.app://connect-return`) and show appropriate status messages.

## Test plan
- [x] All tests pass (19 tests)
- [ ] Test `/connect-return` shows success message
- [ ] Test `/connect-refresh` shows expired session message
- [ ] Test deep linking works when app is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)