### PR TITLE
feat: add test-sentry page

### DIFF
--- a/src/app/test-sentry/page.tsx
+++ b/src/app/test-sentry/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import * as Sentry from '@sentry/nextjs';
+
+export default function TestSentryPage() {
+  const triggerError = () => {
+    try {
+      throw new Error(`Test Sentry Error from Web ${Date.now()}`);
+    } catch (error) {
+      Sentry.captureException(error);
+      alert('Error sent to Sentry! Check your dashboard.');
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center p-8">
+      <h1 className="mb-8 text-2xl font-bold">Sentry Test Page</h1>
+      <button
+        onClick={triggerError}
+        className="rounded-lg bg-red-500 px-6 py-3 text-white hover:bg-red-600"
+      >
+        Trigger Test Error
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a test page at `/test-sentry` to verify Sentry error tracking works in production.

## Test plan
1. Merge and deploy
2. Go to https://discrapp.com/test-sentry (or your domain)
3. Click the button
4. Verify error appears in Sentry discr-web project

🤖 Generated with [Claude Code](https://claude.com/claude-code)