### PR TITLE
fix: include hidden files in artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
           name: cloudflare-build
           path: .open-next
           retention-days: 1
+          include-hidden-files: true
 
   deploy:
     name: Deploy to Cloudflare


### PR DESCRIPTION
## Summary
- Adds `include-hidden-files: true` to upload-artifact step
- The `.open-next` directory starts with a dot, making it hidden
- upload-artifact v4 excludes hidden files by default

## Test plan
- [ ] Build artifact should now upload successfully
- [ ] Deploy should download and use the artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)