### PR TITLE
debug: add DSN status display to test page

### DIFF
--- a/src/app/test-sentry/page.tsx
+++ b/src/app/test-sentry/page.tsx
@@ -2,21 +2,24 @@
 
 import { reportError } from '@/lib/error-reporter';
 
+const DSN_STATUS = process.env.NEXT_PUBLIC_SENTRY_DSN ? 'configured' : 'missing';
+
 export default function TestSentryPage() {
-  const triggerError = () => {
+  const triggerError = async () => {
     try {
       throw new Error(`Test Sentry Error from Web ${Date.now()}`);
     } catch (error) {
       if (error instanceof Error) {
-        reportError(error, { page: 'test-sentry', action: 'button-click' });
+        await reportError(error, { page: 'test-sentry', action: 'button-click' });
       }
-      alert('Error sent to Sentry! Check your dashboard.');
+      alert(`Error sent! DSN status: ${DSN_STATUS}`);
     }
   };
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center p-8">
       <h1 className="mb-8 text-2xl font-bold">Sentry Test Page</h1>
+      <p className="mb-4 text-sm text-gray-600">DSN Status: {DSN_STATUS}</p>
       <button
         onClick={triggerError}
         className="rounded-lg bg-red-500 px-6 py-3 text-white hover:bg-red-600"


### PR DESCRIPTION
Temporary debug to check if NEXT_PUBLIC_SENTRY_DSN is being inlined at build time