### PR TITLE
fix: use text/plain to avoid CORS preflight

### DIFF
--- a/src/lib/error-reporter.ts
+++ b/src/lib/error-reporter.ts
@@ -73,10 +73,11 @@ export async function reportError(error: Error, context?: ErrorContext): Promise
   };
 
   try {
+    // Use text/plain to avoid CORS preflight
     await fetch(endpoint, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
+        'Content-Type': 'text/plain;charset=UTF-8',
       },
       body: JSON.stringify(payload),
     });


### PR DESCRIPTION
Sentry store endpoint blocks CORS preflight. Using text/plain avoids preflight.