### PR TITLE
feat: add Sentry tunnel to bypass ad blockers

### DIFF
--- a/src/app/api/sentry-tunnel/route.ts
+++ b/src/app/api/sentry-tunnel/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const SENTRY_HOST = 'o4510563703193600.ingest.us.sentry.io';
+const SENTRY_PROJECT_ID = '4510563738124288';
+const SENTRY_KEY = 'd49a3b76211657acb27bae4a1dcadbca';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.text();
+
+    // Forward to Sentry
+    const sentryResponse = await fetch(
+      `https://${SENTRY_HOST}/api/${SENTRY_PROJECT_ID}/store/?sentry_key=${SENTRY_KEY}&sentry_version=7`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'text/plain;charset=UTF-8',
+        },
+        body,
+      }
+    );
+
+    return new NextResponse(null, { status: sentryResponse.status });
+  } catch {
+    return new NextResponse(null, { status: 500 });
+  }
+}

--- a/src/lib/error-reporter.ts
+++ b/src/lib/error-reporter.ts
@@ -40,8 +40,9 @@ export async function reportError(error: Error, context?: ErrorContext): Promise
     return;
   }
 
-  const { publicKey, projectId, host } = parsed;
-  const endpoint = `https://${host}/api/${projectId}/store/?sentry_key=${publicKey}&sentry_version=7`;
+  const { publicKey } = parsed;
+  // Use tunnel to bypass ad blockers
+  const endpoint = '/api/sentry-tunnel';
 
   const payload = {
     event_id: crypto.randomUUID().replace(/-/g, ''),


### PR DESCRIPTION
Adds /api/sentry-tunnel endpoint that proxies errors to Sentry, bypassing Brave Shields and other ad blockers.