### PR TITLE
feat: add tests for checkout and order pages

### DIFF
--- a/__tests__/checkout-cancel/page.test.tsx
+++ b/__tests__/checkout-cancel/page.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import CheckoutCancelPage from '@/app/checkout-cancel/page';
+
+// Mock next/navigation
+const mockSearchParams = new URLSearchParams();
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+}));
+
+// Suppress the jsdom navigation error
+const originalError = console.error;
+beforeAll(() => {
+  console.error = (...args: unknown[]) => {
+    if (
+      typeof args[0] === 'object' &&
+      args[0] !== null &&
+      'type' in args[0] &&
+      (args[0] as { type: string }).type === 'not implemented'
+    ) {
+      return;
+    }
+    originalError.call(console, ...args);
+  };
+});
+
+afterAll(() => {
+  console.error = originalError;
+});
+
+describe('CheckoutCancelPage', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockSearchParams.delete('order_id');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders payment cancelled message', () => {
+    render(<CheckoutCancelPage />);
+    expect(screen.getByText('Payment Cancelled')).toBeInTheDocument();
+  });
+
+  it('renders cancellation description', () => {
+    render(<CheckoutCancelPage />);
+    expect(
+      screen.getByText('Your payment was cancelled. No charges were made.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders close window instruction', () => {
+    render(<CheckoutCancelPage />);
+    expect(
+      screen.getByText('You can close this window and return to the app.')
+    ).toBeInTheDocument();
+  });
+
+  it('displays order ID when provided in search params', () => {
+    mockSearchParams.set('order_id', 'order_123');
+    render(<CheckoutCancelPage />);
+    expect(screen.getByText('Order ID: order_123')).toBeInTheDocument();
+  });
+
+  it('does not display order ID when not provided', () => {
+    render(<CheckoutCancelPage />);
+    expect(screen.queryByText(/Order ID:/)).not.toBeInTheDocument();
+  });
+
+  it('renders cancel emoji', () => {
+    render(<CheckoutCancelPage />);
+    expect(screen.getByText('❌')).toBeInTheDocument();
+  });
+});

--- a/__tests__/checkout-success/page.test.tsx
+++ b/__tests__/checkout-success/page.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import CheckoutSuccessPage from '@/app/checkout-success/page';
+
+// Mock next/navigation
+const mockSearchParams = new URLSearchParams();
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+}));
+
+// Suppress the jsdom navigation error
+const originalError = console.error;
+beforeAll(() => {
+  console.error = (...args: unknown[]) => {
+    if (
+      typeof args[0] === 'object' &&
+      args[0] !== null &&
+      'type' in args[0] &&
+      (args[0] as { type: string }).type === 'not implemented'
+    ) {
+      return;
+    }
+    originalError.call(console, ...args);
+  };
+});
+
+afterAll(() => {
+  console.error = originalError;
+});
+
+describe('CheckoutSuccessPage', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockSearchParams.delete('order_id');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders payment successful message', () => {
+    render(<CheckoutSuccessPage />);
+    expect(screen.getByText('Payment Successful!')).toBeInTheDocument();
+  });
+
+  it('renders success description', () => {
+    render(<CheckoutSuccessPage />);
+    expect(
+      screen.getByText('Your order has been placed successfully.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders close window instruction', () => {
+    render(<CheckoutSuccessPage />);
+    expect(
+      screen.getByText('You can close this window and return to the app.')
+    ).toBeInTheDocument();
+  });
+
+  it('displays order ID when provided in search params', () => {
+    mockSearchParams.set('order_id', 'order_789');
+    render(<CheckoutSuccessPage />);
+    expect(screen.getByText('Order ID: order_789')).toBeInTheDocument();
+  });
+
+  it('does not display order ID when not provided', () => {
+    render(<CheckoutSuccessPage />);
+    expect(screen.queryByText(/Order ID:/)).not.toBeInTheDocument();
+  });
+
+  it('renders success emoji', () => {
+    render(<CheckoutSuccessPage />);
+    expect(screen.getByText('✅')).toBeInTheDocument();
+  });
+});

--- a/__tests__/order-updated/page.test.tsx
+++ b/__tests__/order-updated/page.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import OrderUpdatedPage from '@/app/order-updated/page';
+
+// Mock next/navigation
+const mockSearchParams = new URLSearchParams();
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+}));
+
+describe('OrderUpdatedPage', () => {
+  beforeEach(() => {
+    mockSearchParams.delete('order');
+    mockSearchParams.delete('status');
+    mockSearchParams.delete('error');
+  });
+
+  describe('success state', () => {
+    it('renders order updated message', () => {
+      render(<OrderUpdatedPage />);
+      expect(screen.getByText('Order Updated!')).toBeInTheDocument();
+    });
+
+    it('renders default status when not provided', () => {
+      render(<OrderUpdatedPage />);
+      expect(screen.getByText(/Status:/)).toBeInTheDocument();
+      expect(screen.getByText('Updated')).toBeInTheDocument();
+    });
+
+    it('renders custom status when provided', () => {
+      mockSearchParams.set('status', 'shipped');
+      render(<OrderUpdatedPage />);
+      expect(screen.getByText('Shipped')).toBeInTheDocument();
+    });
+
+    it('capitalizes status correctly', () => {
+      mockSearchParams.set('status', 'processing');
+      render(<OrderUpdatedPage />);
+      expect(screen.getByText('Processing')).toBeInTheDocument();
+    });
+
+    it('displays order number when provided', () => {
+      mockSearchParams.set('order', 'ORD-12345');
+      render(<OrderUpdatedPage />);
+      expect(screen.getByText('ORD-12345')).toBeInTheDocument();
+    });
+
+    it('does not display order number when not provided', () => {
+      render(<OrderUpdatedPage />);
+      expect(screen.queryByText(/ORD-/)).not.toBeInTheDocument();
+    });
+
+    it('renders close window instruction', () => {
+      render(<OrderUpdatedPage />);
+      expect(screen.getByText('You can close this window.')).toBeInTheDocument();
+    });
+  });
+
+  describe('error state', () => {
+    it('renders error message when error param is present', () => {
+      mockSearchParams.set('error', 'Something went wrong');
+      render(<OrderUpdatedPage />);
+      expect(screen.getByText('Update Failed')).toBeInTheDocument();
+    });
+
+    it('displays decoded error message', () => {
+      mockSearchParams.set('error', 'Order%20not%20found');
+      render(<OrderUpdatedPage />);
+      expect(screen.getByText('Order not found')).toBeInTheDocument();
+    });
+
+    it('renders close window instruction in error state', () => {
+      mockSearchParams.set('error', 'Some error');
+      render(<OrderUpdatedPage />);
+      expect(screen.getByText('You can close this window.')).toBeInTheDocument();
+    });
+
+    it('does not show order updated message in error state', () => {
+      mockSearchParams.set('error', 'Some error');
+      render(<OrderUpdatedPage />);
+      expect(screen.queryByText('Order Updated!')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('with all params', () => {
+    it('shows error state even when other params are present', () => {
+      mockSearchParams.set('order', 'ORD-999');
+      mockSearchParams.set('status', 'shipped');
+      mockSearchParams.set('error', 'Failed to update');
+      render(<OrderUpdatedPage />);
+      expect(screen.getByText('Update Failed')).toBeInTheDocument();
+      expect(screen.queryByText('Order Updated!')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/ship-order/page.test.tsx
+++ b/__tests__/ship-order/page.test.tsx
@@ -1,0 +1,267 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ShipOrderPage from '@/app/ship-order/page';
+
+// Mock next/navigation
+const mockSearchParams = new URLSearchParams();
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+}));
+
+describe('ShipOrderPage', () => {
+  const mockFetch = jest.fn();
+
+  beforeEach(() => {
+    mockSearchParams.delete('token');
+    global.fetch = mockFetch;
+    mockFetch.mockClear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('without token', () => {
+    it('renders invalid link message', () => {
+      render(<ShipOrderPage />);
+      expect(screen.getByText('Invalid Link')).toBeInTheDocument();
+    });
+
+    it('explains missing token', () => {
+      render(<ShipOrderPage />);
+      expect(
+        screen.getByText('This link is missing the required printer token.')
+      ).toBeInTheDocument();
+    });
+
+    it('does not show form', () => {
+      render(<ShipOrderPage />);
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /mark as shipped/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('with token', () => {
+    beforeEach(() => {
+      mockSearchParams.set('token', 'printer_token_123');
+    });
+
+    it('renders form title', () => {
+      render(<ShipOrderPage />);
+      expect(screen.getByText('Mark Order as Shipped')).toBeInTheDocument();
+    });
+
+    it('renders tracking number input', () => {
+      render(<ShipOrderPage />);
+      expect(
+        screen.getByPlaceholderText('Enter tracking number (optional)')
+      ).toBeInTheDocument();
+    });
+
+    it('renders submit button', () => {
+      render(<ShipOrderPage />);
+      expect(
+        screen.getByRole('button', { name: 'Mark as Shipped' })
+      ).toBeInTheDocument();
+    });
+
+    it('allows entering tracking number', () => {
+      render(<ShipOrderPage />);
+
+      const input = screen.getByPlaceholderText(
+        'Enter tracking number (optional)'
+      );
+      fireEvent.change(input, { target: { value: 'TRACK123' } });
+
+      expect(input).toHaveValue('TRACK123');
+    });
+  });
+
+  describe('form submission', () => {
+    beforeEach(() => {
+      mockSearchParams.set('token', 'printer_token_123');
+    });
+
+    it('submits without tracking number', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            success: true,
+            order: { order_number: 'ORD-001' },
+          }),
+      });
+
+      render(<ShipOrderPage />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Mark as Shipped' }));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://xhaogdigrsiwxdjmjzgx.supabase.co/functions/v1/update-order-status',
+          expect.objectContaining({
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              printer_token: 'printer_token_123',
+              status: 'shipped',
+            }),
+          })
+        );
+      });
+    });
+
+    it('submits with tracking number', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            success: true,
+            order: { order_number: 'ORD-001' },
+          }),
+      });
+
+      render(<ShipOrderPage />);
+
+      const input = screen.getByPlaceholderText(
+        'Enter tracking number (optional)'
+      );
+      fireEvent.change(input, { target: { value: 'TRACK456' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Mark as Shipped' }));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            body: JSON.stringify({
+              printer_token: 'printer_token_123',
+              status: 'shipped',
+              tracking_number: 'TRACK456',
+            }),
+          })
+        );
+      });
+    });
+
+    it('shows success message after successful submission', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            success: true,
+            order: { order_number: 'ORD-002' },
+          }),
+      });
+
+      render(<ShipOrderPage />);
+      fireEvent.click(screen.getByRole('button', { name: 'Mark as Shipped' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Order Shipped!')).toBeInTheDocument();
+      });
+      expect(screen.getByText('ORD-002')).toBeInTheDocument();
+      expect(screen.getByText('Order marked as shipped!')).toBeInTheDocument();
+    });
+
+    it('shows tracking number in success message when provided', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            success: true,
+            order: { order_number: 'ORD-003' },
+          }),
+      });
+
+      render(<ShipOrderPage />);
+      const input = screen.getByPlaceholderText(
+        'Enter tracking number (optional)'
+      );
+      fireEvent.change(input, { target: { value: 'TRACK789' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Mark as Shipped' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Order Shipped!')).toBeInTheDocument();
+      });
+      expect(screen.getByText('TRACK789')).toBeInTheDocument();
+    });
+
+    it('shows error message on API failure', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        json: () => Promise.resolve({ error: 'Order not found' }),
+      });
+
+      render(<ShipOrderPage />);
+      fireEvent.click(screen.getByRole('button', { name: 'Mark as Shipped' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Update Failed')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Order not found')).toBeInTheDocument();
+    });
+
+    it('shows default error message when API returns no error', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        json: () => Promise.resolve({}),
+      });
+
+      render(<ShipOrderPage />);
+      fireEvent.click(screen.getByRole('button', { name: 'Mark as Shipped' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Update Failed')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Failed to update order')).toBeInTheDocument();
+    });
+
+    it('shows network error message on fetch failure', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      render(<ShipOrderPage />);
+      fireEvent.click(screen.getByRole('button', { name: 'Mark as Shipped' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Update Failed')).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText('Network error. Please try again.')
+      ).toBeInTheDocument();
+    });
+
+    it('shows Try Again button on error', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      render(<ShipOrderPage />);
+      fireEvent.click(screen.getByRole('button', { name: 'Mark as Shipped' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Try Again' })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('returns to form when Try Again is clicked', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      render(<ShipOrderPage />);
+      fireEvent.click(screen.getByRole('button', { name: 'Mark as Shipped' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Try Again' })
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Try Again' }));
+
+      expect(screen.getByText('Mark Order as Shipped')).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText('Enter tracking number (optional)')
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds tests for checkout-cancel page (6 tests, 91% coverage)
- Adds tests for checkout-success page (6 tests, 91% coverage)
- Adds tests for order-updated page (12 tests, 100% coverage)
- Adds tests for ship-order page (16 tests, 87% coverage)

## Mocking Strategy
- **next/navigation**: Mocks `useSearchParams` to control URL parameters
- **fetch API**: Mocks global fetch for Supabase API calls in ship-order
- **jsdom errors**: Suppresses navigation errors for deep link testing

## Test Coverage Improvements
| File | Before | After |
|------|--------|-------|
| checkout-cancel | 0% | 91% |
| checkout-success | 0% | 91% |
| order-updated | 0% | 100% |
| ship-order | 0% | 87% |

Total tests: 153 (up from 113)

## Test plan
- [x] All 40 new tests pass
- [x] Full test suite (153 tests) passes
- [x] Lint passes
- [x] Fetch calls are properly mocked (no real API calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)