### PR TITLE
ci: add cleanup job for PR preview deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, closed]
   push:
     branches:
       - main
@@ -15,6 +16,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.action != 'closed'
     steps:
       - uses: actions/checkout@v4
 
@@ -31,6 +33,7 @@ jobs:
 
   test:
     name: Test
+    if: github.event_name == 'push' || github.event.action != 'closed'
     uses: discrapp/.github/.github/workflows/test.yml@main
     with:
       coverage_threshold: 100
@@ -43,6 +46,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.action != 'closed'
     steps:
       - uses: actions/checkout@v4
 
@@ -71,7 +75,7 @@ jobs:
     name: Deploy Preview
     runs-on: ubuntu-latest
     needs: [lint, test, build]
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     outputs:
       preview_url: ${{ steps.deploy.outputs.preview_url }}
     permissions:
@@ -167,7 +171,7 @@ jobs:
     name: Lighthouse Audit
     runs-on: ubuntu-latest
     needs: deploy-preview
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     permissions:
       pull-requests: write
     steps:
@@ -276,6 +280,25 @@ jobs:
 
       - name: Deploy to Cloudflare Workers
         run: npm run deploy:only
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+  cleanup-preview:
+    name: Cleanup Preview
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    steps:
+      - name: Delete Preview Worker
+        run: |
+          WORKER_NAME="discr-web-pr-${{ github.event.pull_request.number }}"
+          echo "Deleting preview worker: $WORKER_NAME"
+
+          # Use Cloudflare API directly to avoid wrangler using local config
+          curl -s -X DELETE \
+            "https://api.cloudflare.com/client/v4/accounts/${{ secrets.CLOUDFLARE_ACCOUNT_ID }}/workers/scripts/$WORKER_NAME" \
+            -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+            -H "Content-Type: application/json" | jq .
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

- Adds a `cleanup-preview` job that runs when PRs are closed (merged or abandoned)
- Uses Cloudflare API directly to delete preview workers (avoids wrangler config file issues)
- Adds conditions to skip CI jobs (lint/test/build/deploy-preview/lighthouse) on PR close
- Prevents preview workers from accumulating in the Cloudflare account

## Test plan

- [ ] Verify CI jobs still run on PR open/update
- [ ] Verify CI jobs still run on push to main
- [ ] Verify cleanup job runs when PR is closed
- [ ] Verify preview worker is deleted after PR merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)