### PR TITLE
chore: add custom domain routes to wrangler config

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,8 +4,13 @@
   "main": ".open-next/worker.js",
   "compatibility_date": "2024-12-30",
   "compatibility_flags": ["nodejs_compat"],
+  "workers_dev": true,
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"
-  }
+  },
+  "routes": [
+    { "pattern": "discrapp.com", "custom_domain": true },
+    { "pattern": "www.discrapp.com", "custom_domain": true }
+  ]
 }


### PR DESCRIPTION
## Summary
- Enable workers_dev URL
- Add custom domain routes for discrapp.com and www.discrapp.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)