### PR TITLE
fix: remove custom_domain to prevent DNS recreation on deploy

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,9 +8,8 @@
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"
-  },
-  "routes": [
-    { "pattern": "discrapp.com", "custom_domain": true },
-    { "pattern": "www.discrapp.com", "custom_domain": true }
-  ]
+  }
+  // Custom domains configured manually in Cloudflare Workers Routes
+  // to avoid DNS recreation on each deploy.
+  // Routes: discrapp.com/* and www.discrapp.com/* -> discr-web worker
 }


### PR DESCRIPTION
## Summary
- Remove routes with custom_domain from wrangler.jsonc
- Custom domains should be configured manually in Cloudflare Workers Routes to avoid DNS recreation on each deploy

## Changes
- wrangler.jsonc: Removed routes configuration, added comment explaining manual setup

## Test plan
- [ ] Deploy to Cloudflare
- [ ] Verify site stays up after merge
- [ ] Confirm Workers Routes are manually configured in Cloudflare dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)