### PR TITLE
feat: add privacy and terms pages to sitemap for SEO

### DIFF
--- a/__tests__/sitemap.test.ts
+++ b/__tests__/sitemap.test.ts
@@ -39,6 +39,28 @@ describe('sitemap', () => {
     expect(checkoutCancel?.changeFrequency).toBe('monthly');
   });
 
+  it('includes privacy policy page', () => {
+    const result = sitemap();
+    const privacy = result.find(
+      (entry) => entry.url === 'https://discrapp.com/privacy'
+    );
+
+    expect(privacy).toBeDefined();
+    expect(privacy?.priority).toBe(0.5);
+    expect(privacy?.changeFrequency).toBe('yearly');
+  });
+
+  it('includes terms of service page', () => {
+    const result = sitemap();
+    const terms = result.find(
+      (entry) => entry.url === 'https://discrapp.com/terms'
+    );
+
+    expect(terms).toBeDefined();
+    expect(terms?.priority).toBe(0.5);
+    expect(terms?.changeFrequency).toBe('yearly');
+  });
+
   it('includes lastModified date for all entries', () => {
     const result = sitemap();
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -22,5 +22,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'monthly',
       priority: 0.3,
     },
+    {
+      url: `${baseUrl}/privacy`,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.5,
+    },
+    {
+      url: `${baseUrl}/terms`,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.5,
+    },
   ];
 }


### PR DESCRIPTION
## Summary
- Add privacy policy page to sitemap.xml with yearly change frequency
- Add terms of service page to sitemap.xml with yearly change frequency
- Both pages have medium priority (0.5) for SEO discoverability
- Updated tests to verify sitemap includes new pages

Closes #60

## Test plan
- [x] Run `npm test -- sitemap.test.ts` to verify tests pass
- [x] All 233 tests pass
- [ ] Verify sitemap.xml includes privacy and terms URLs after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)