### PR TITLE
feat: unify dark mode colors with Material Design standard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -612,7 +612,24 @@ describe('NewSection', () => {
 });
 ```
 
-### Tailwind Dark Mode Pattern
+### Unified Color System (consistent across mobile, web, admin)
+
+**Dark Mode Surfaces (Material Design elevation):**
+
+| Purpose | Hex | CSS Variable | Tailwind |
+|---------|-----|--------------|----------|
+| Background | `#121212` | `var(--background)` | `bg-background` |
+| Card/Surface | `#1e1e1e` | `var(--surface-card)` | `dark:bg-zinc-900` |
+| Elevated | `#252525` | `var(--surface-elevated)` | `dark:bg-zinc-800` |
+| Border | `#2e2e2e` | `var(--surface-border)` | `dark:border-zinc-700` |
+
+**Light Mode:**
+
+- Background: `#fff`
+- Cards: `#f8f8f8` / `dark:bg-zinc-50`
+- Borders: `#eee`, `#ddd`
+
+**Tailwind Pattern:**
 
 ```typescript
 // Always include both light and dark variants

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,8 +29,13 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
+    --background: #121212;
     --foreground: #ededed;
+
+    /* Dark mode surface colors (unified with mobile) */
+    --surface-card: #1e1e1e;
+    --surface-elevated: #252525;
+    --surface-border: #2e2e2e;
   }
 }
 


### PR DESCRIPTION
## Summary

- Update dark mode background from `#0a0a0a` to `#121212`
- Add surface CSS variables for cards, elevated surfaces, and borders
- Update CLAUDE.md with unified color system documentation

## Unified Color System

| Purpose | Hex | CSS Variable |
|---------|-----|--------------|
| Background | `#121212` | `var(--background)` |
| Card/Surface | `#1e1e1e` | `var(--surface-card)` |
| Elevated | `#252525` | `var(--surface-elevated)` |
| Border | `#2e2e2e` | `var(--surface-border)` |

This aligns web dark mode with mobile and admin for a consistent user experience.

## Test plan

- [ ] Test landing page in dark mode
- [ ] Verify QR code lookup page contrast
- [ ] Check violet brand colors are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)